### PR TITLE
fix: Set intermediate value when element is blurred or up/down arrow keys are used

### DIFF
--- a/.changeset/grumpy-frogs-provide.md
+++ b/.changeset/grumpy-frogs-provide.md
@@ -1,0 +1,5 @@
+---
+'timescape': patch
+---
+
+Set value from intermediate value when focus is lost or up/down arrow keys are used.

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -317,6 +317,23 @@ export class TimescapeManager implements Options {
     return date
   }
 
+  #clearIntermediateState(registryEntry: RegistryEntry) {
+    const { intermediateValue, type } = registryEntry
+    if (intermediateValue) {
+      this.#setValidatedDate(
+        set(
+          this.#currentDate,
+          type,
+          type === 'months'
+            ? Number(intermediateValue) - 1
+            : Number(intermediateValue),
+        ),
+      )
+      registryEntry.intermediateValue = ''
+      this.#cursorPosition = 0
+    }
+  }
+
   #handleKeyDown(e: KeyboardEvent) {
     const registryEntry = [...this.#registry.values()].find(
       ({ inputElement }) => inputElement === e.target,
@@ -329,6 +346,7 @@ export class TimescapeManager implements Options {
     switch (e.key) {
       case 'ArrowUp':
       case 'ArrowDown':
+        this.#clearIntermediateState(registryEntry)
         const date = this.#currentDate
 
         if (type === 'am/pm') {
@@ -500,6 +518,12 @@ export class TimescapeManager implements Options {
   #handleBlur(e: FocusEvent) {
     requestAnimationFrame(() => {
       if (e.target !== document.activeElement) {
+        const registryEntry = [...this.#registry.values()].find(
+          ({ inputElement }) => inputElement === e.target,
+        )
+        if (registryEntry) {
+          this.#clearIntermediateState(registryEntry)
+        }
         const target = e.target as HTMLInputElement
         target.removeAttribute('aria-selected')
       }

--- a/packages/lib/test/timescape.test.ts
+++ b/packages/lib/test/timescape.test.ts
@@ -746,6 +746,33 @@ describe('timescape', () => {
       fireEvent.keyDown(document.activeElement, { key: 'ArrowRight' })
       expect(fields.days).toHaveValue('9')
     })
+
+    it('should allow up/down keys when there is an intermediate value', () => {
+      document.body.appendChild(container)
+
+      const fields = getFields()
+
+      fields.minutes.focus()
+      fireEvent.keyDown(document.activeElement, { key: '3' })
+      fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' })
+      expect(fields.minutes).toHaveValue('04')
+
+      fields.months.focus()
+      fireEvent.keyDown(document.activeElement, { key: '1' })
+      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' })
+      expect(fields.months).toHaveValue('12')
+    })
+
+    it('should set value to intermediate value when focus is lost', () => {
+      document.body.appendChild(container)
+
+      const fields = getFields()
+
+      fields.minutes.focus()
+      fireEvent.keyDown(document.activeElement, { key: '3' })
+      fields.hours.focus()
+      expect(fields.minutes).toHaveValue('03')
+    })
   })
 
   it('should support setting options on constructor', () => {


### PR DESCRIPTION
The intermediate value was never cleared and set when any other interaction with the element occurred.

Fixes #4 

cc @fweinaug

[**Preview Storybook**](https://fix-intermediate-value.timescape.pages.dev) (I hoped that the Cloudflare integration would post this automatically)