### PR TITLE
#19 add support from `a` and `p` keys to change day period

### DIFF
--- a/.changeset/hot-balloons-dress.md
+++ b/.changeset/hot-balloons-dress.md
@@ -1,0 +1,5 @@
+---
+'timescape': patch
+---
+
+Allow switching AM/PM on mobile

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -451,7 +451,10 @@ export class TimescapeManager implements Options {
       default:
         const { key } = e
 
-        if (!/^\d$/.test(key)) return
+        if (!/^\d$/.test(key)) {
+          e.preventDefault()
+          return
+        }
 
         const number = Number(key)
 

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -431,6 +431,24 @@ export class TimescapeManager implements Options {
         break
       case 'Backspace':
         break
+      case 'a':
+      case 'A':
+      case 'p':
+      case 'P':
+        if (type === 'am/pm') {
+          const isAMKey = e.key.toLowerCase() === 'a'
+          const isPMKey = e.key.toLowerCase() === 'p'
+
+          const date = this.#currentDate
+          const isAM = date.getHours() < 12
+
+          if (isAM && isPMKey) {
+            this.#setValidatedDate(add(date, 'hours', 12))
+          } else if (!isAM && isAMKey) {
+            this.#setValidatedDate(add(date, 'hours', -12))
+          }
+        }
+        break
       default:
         const { key } = e
 

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -437,12 +437,11 @@ export class TimescapeManager implements Options {
       case 'P':
         if (type === 'am/pm') {
           const isAMKey = e.key.toLowerCase() === 'a'
-          const isPMKey = e.key.toLowerCase() === 'p'
 
           const date = this.#currentDate
           const isAM = date.getHours() < 12
 
-          if (isAM && isPMKey) {
+          if (isAM && !isAMKey) {
             this.#setValidatedDate(add(date, 'hours', 12))
           } else if (!isAM && isAMKey) {
             this.#setValidatedDate(add(date, 'hours', -12))

--- a/packages/lib/test/timescape.test.ts
+++ b/packages/lib/test/timescape.test.ts
@@ -371,6 +371,28 @@ describe('timescape', () => {
       expect(fields.seconds).toHaveValue('00')
       expect(fields.ampm).toHaveValue('AM')
     })
+
+    it('should change 12-hour mode period value with `p`/`a` keys', () => {
+      document.body.appendChild(container)
+      manager.hour12 = true
+
+      const fields = getFields()
+
+      expect(fields.ampm).toHaveValue('PM')
+
+      fields.ampm.focus()
+      fireEvent.keyDown(document.activeElement!, { key: 'a' })
+      expect(fields.ampm).toHaveValue('AM')
+
+      fireEvent.keyDown(document.activeElement!, { key: 'p' })
+      expect(fields.ampm).toHaveValue('PM')
+
+      fireEvent.keyDown(document.activeElement!, { key: 'A' })
+      expect(fields.ampm).toHaveValue('AM')
+
+      fireEvent.keyDown(document.activeElement!, { key: 'P' })
+      expect(fields.ampm).toHaveValue('PM')
+    })
   })
 
   describe('steps', () => {


### PR DESCRIPTION
Closes https://github.com/dan-lee/timescape/issues/19

Could not check if it works in storybook due to errors, maybe because I am on windows, but tests seem to run fine, if you could check I'd be grateful 🙂.

```
PS C:\other\timescape> pnpm demo

> @timescape/root@0.0.0 demo C:\other\timescape
> pnpm --filter demo run dev


> demo@1.2.3 dev C:\other\timescape\packages\demo
> concurrently -n 'integration,storybook' 'pnpm vite --port 4949' 'pnpm storybook:dev --no-open'

['integration] ''pnpm' is not recognized as an internal or external command,
['integration] operable program or batch file.
[2] ''pnpm' is not recognized as an internal or external command,
[2] operable program or batch file.
[2] 'pnpm exited with code 1
['integration] 'pnpm exited with code 1
[3] The filename, directory name, or volume label syntax is incorrect.
[3] storybook:dev exited with code 1
```