### PR TITLE
refactor(core): allow more permissive event propagation on `keydown`

### DIFF
--- a/.changeset/thirty-carpets-hang.md
+++ b/.changeset/thirty-carpets-hang.md
@@ -1,0 +1,5 @@
+---
+'timescape': minor
+---
+
+Allow native key events to be passed through in the `keydown`

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -430,6 +430,7 @@ export class TimescapeManager implements Options {
         this.#focusNextField(type, -1)
         break
       case 'Backspace':
+      case 'Tab':
         break
       case 'a':
       case 'A':
@@ -578,8 +579,11 @@ export class TimescapeManager implements Options {
         break
     }
 
-    e.preventDefault()
-    e.stopPropagation()
+    // Prevent the default behavior for all keys except these
+    if (!['Tab'].includes(e.key)) {
+      e.preventDefault()
+      e.stopPropagation()
+    }
   }
 
   #handleClick(e: MouseEvent) {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -431,6 +431,9 @@ export class TimescapeManager implements Options {
       case key === 'Enter':
         this.#focusNextField(type)
         break
+      case key === 'Tab':
+        allowNativeEvent = !this.#focusNextField(type, 1, false)
+        break
       case key === 'ArrowLeft':
         this.#focusNextField(type, -1)
         break
@@ -722,6 +725,8 @@ export class TimescapeManager implements Options {
     ) {
       this.#pubsub.emit('focusWrap', offset === -1 ? 'start' : 'end')
     }
+
+    return !!nextIndex
   }
 }
 

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -709,7 +709,11 @@ export class TimescapeManager implements Options {
     this.#pubsub.emit('changeDate', date)
   }
 
-  #focusNextField(type: DateType, offset = 1, wrap = true) {
+  /**
+   *
+   * @returns {Boolean} Whether the next field was focused or not
+   */
+  #focusNextField(type: DateType, offset = 1, wrap = true): boolean {
     const types = [...this.#registry.keys()]
     const index = types.indexOf(type)
 

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -387,9 +387,13 @@ export class TimescapeManager implements Options {
 
     const { inputElement, intermediateValue, type } = registryEntry
 
-    switch (e.key) {
-      case 'ArrowUp':
-      case 'ArrowDown':
+    let allowNativeEvent = false
+
+    const key = e.key
+
+    switch (true) {
+      case key === 'ArrowUp':
+      case key === 'ArrowDown':
         this.#clearIntermediateState(registryEntry)
         const date = this.#currentDate
 
@@ -423,19 +427,17 @@ export class TimescapeManager implements Options {
             : add(date, type, step),
         )
         break
-      case 'ArrowRight':
+      case key === 'ArrowRight':
+      case key === 'Enter':
         this.#focusNextField(type)
         break
-      case 'ArrowLeft':
+      case key === 'ArrowLeft':
         this.#focusNextField(type, -1)
         break
-      case 'Backspace':
-      case 'Tab':
-        break
-      case 'a':
-      case 'A':
-      case 'p':
-      case 'P':
+      case key === 'a':
+      case key === 'A':
+      case key === 'p':
+      case key === 'P':
         if (type === 'am/pm') {
           const isAMKey = e.key.toLowerCase() === 'a'
 
@@ -449,14 +451,7 @@ export class TimescapeManager implements Options {
           }
         }
         break
-      default:
-        const { key } = e
-
-        if (!/^\d$/.test(key)) {
-          e.preventDefault()
-          return
-        }
-
+      case /^\d$/.test(key):
         const number = Number(key)
 
         const setIntermediateValue = (value: string) => {
@@ -577,10 +572,12 @@ export class TimescapeManager implements Options {
             break
         }
         break
+      default:
+        allowNativeEvent = true
+        break
     }
 
-    // Prevent the default behavior for all keys except these
-    if (!['Tab'].includes(e.key)) {
+    if (!allowNativeEvent) {
       e.preventDefault()
       e.stopPropagation()
     }

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -432,7 +432,8 @@ export class TimescapeManager implements Options {
         this.#focusNextField(type)
         break
       case key === 'Tab':
-        allowNativeEvent = !this.#focusNextField(type, 1, false)
+        const tabOffset = e.shiftKey ? -1 : 1
+        allowNativeEvent = !this.#focusNextField(type, tabOffset, false)
         break
       case key === 'ArrowLeft':
         this.#focusNextField(type, -1)

--- a/packages/lib/test/timescape.test.ts
+++ b/packages/lib/test/timescape.test.ts
@@ -220,6 +220,17 @@ describe('timescape', () => {
       expect(years).toHaveFocus()
     })
 
+    it('should focus the first element by Tab key', () => {
+      document.body.appendChild(container)
+      const { years, months } = getFields()
+
+      years.focus()
+      expect(years).toHaveFocus()
+
+      fireEvent.keyDown(document.activeElement!, { key: 'Tab' })
+      expect(months).toHaveFocus()
+    })
+
     it('should cycle through fields by arrow keys', () => {
       document.body.appendChild(container)
       const { years, months, days, hours, minutes, seconds, ampm } = getFields()

--- a/packages/lib/test/timescape.test.ts
+++ b/packages/lib/test/timescape.test.ts
@@ -222,15 +222,12 @@ describe('timescape', () => {
 
     it('should focus the second element by the Tab key', () => {
       document.body.appendChild(container)
-      const { years } = getFields()
+      const { years, months } = getFields()
 
       years.focus()
       expect(years).toHaveFocus()
 
       fireEvent.keyDown(document.activeElement!, { key: 'Tab' })
-
-      const { months } = getFields()
-
       expect(months).toHaveFocus()
     })
 

--- a/packages/lib/test/timescape.test.ts
+++ b/packages/lib/test/timescape.test.ts
@@ -220,7 +220,7 @@ describe('timescape', () => {
       expect(years).toHaveFocus()
     })
 
-    it('should focus the first element by Tab key', () => {
+    it('should focus the second element by the Tab key', () => {
       document.body.appendChild(container)
       const { years, months } = getFields()
 

--- a/packages/lib/test/timescape.test.ts
+++ b/packages/lib/test/timescape.test.ts
@@ -220,17 +220,6 @@ describe('timescape', () => {
       expect(years).toHaveFocus()
     })
 
-    it('should focus the second element by the Tab key', () => {
-      document.body.appendChild(container)
-      const { years, months } = getFields()
-
-      years.focus()
-      expect(years).toHaveFocus()
-
-      fireEvent.keyDown(document.activeElement!, { key: 'Tab' })
-      expect(months).toHaveFocus()
-    })
-
     it('should cycle through fields by Enter key', () => {
       document.body.appendChild(container)
       const { years, months, days, hours, minutes, seconds, ampm } = getFields()
@@ -254,6 +243,20 @@ describe('timescape', () => {
       }
     })
 
+    it('should cycle through fields by the Tab key', () => {
+      document.body.appendChild(container)
+      const { years, months, days, hours, minutes, seconds, ampm } = getFields()
+
+      years.focus()
+      expect(years).toHaveFocus()
+
+      const elements = [months, days, hours, minutes, seconds, ampm]
+      for (const element of elements) {
+        fireEvent.keyDown(document.activeElement!, { key: 'Tab' })
+        expect(element).toHaveFocus()
+      }
+    })
+
     it('should cycle through fields by arrow keys', () => {
       document.body.appendChild(container)
       const { years, months, days, hours, minutes, seconds, ampm } = getFields()
@@ -273,6 +276,23 @@ describe('timescape', () => {
       ]
       for (const element of elements) {
         fireEvent.keyDown(document.activeElement!, { key: 'ArrowRight' })
+        expect(element).toHaveFocus()
+      }
+    })
+
+    it('should cycle through fields by Tab key in reverse', () => {
+      document.body.appendChild(container)
+      const { years, months, days, hours, minutes, seconds, ampm } = getFields()
+
+      ampm.focus()
+      expect(ampm).toHaveFocus()
+
+      const orderedElements = [seconds, minutes, hours, days, months, years]
+      for (const element of orderedElements) {
+        fireEvent.keyDown(document.activeElement!, {
+          key: 'Tab',
+          shiftKey: true,
+        })
         expect(element).toHaveFocus()
       }
     })

--- a/packages/lib/test/timescape.test.ts
+++ b/packages/lib/test/timescape.test.ts
@@ -222,13 +222,39 @@ describe('timescape', () => {
 
     it('should focus the second element by the Tab key', () => {
       document.body.appendChild(container)
-      const { years, months } = getFields()
+      const { years } = getFields()
 
       years.focus()
       expect(years).toHaveFocus()
 
       fireEvent.keyDown(document.activeElement!, { key: 'Tab' })
+
+      const { months } = getFields()
+
       expect(months).toHaveFocus()
+    })
+
+    it('should cycle through fields by Enter key', () => {
+      document.body.appendChild(container)
+      const { years, months, days, hours, minutes, seconds, ampm } = getFields()
+
+      years.focus()
+      expect(years).toHaveFocus()
+
+      const elements = [
+        months,
+        days,
+        hours,
+        minutes,
+        seconds,
+        ampm,
+        // start from beginning
+        years,
+      ]
+      for (const element of elements) {
+        fireEvent.keyDown(document.activeElement!, { key: 'Enter' })
+        expect(element).toHaveFocus()
+      }
     })
 
     it('should cycle through fields by arrow keys', () => {


### PR DESCRIPTION
Currently, all `keydown` events have `preventDefault` and `stopPropagation` called on them which makes it a burden on the library to reimplement the _native_ behaviours that are being discarded.

This PR changes the following:
- Refactor the `#focusNextField` method to return a `boolean` representing whether the method actually focused on another element.
- Refactor the `#handleKeyDown` method to use a more granular approach in the matching of `keydown` event keys to their respective internal private methods.

The PR adds the following:
- Allow the pressing of the `Tab` key to focus on the next field or allow native event propagation to take place if there isn't another element to focus on.
- Allow the pressing of the `Enter` key to focus on the next field using the same implementation of `ArrowRight`.

Unit tests have been added to cover both additions of the keyboard navigation events for `Enter` and `Tab`.

Fixes #22 