### PR TITLE
export STOP_EVENT_PROPAGATION

### DIFF
--- a/.changeset/three-baboons-buy.md
+++ b/.changeset/three-baboons-buy.md
@@ -1,0 +1,5 @@
+---
+"timescape": patch
+---
+
+export `STOP_EVENT_PROPAGATION`

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -39,6 +39,8 @@ type Registry = Map<DateType, RegistryEntry>;
 export const $NOW = "$NOW" as const;
 export type $NOW = typeof $NOW;
 
+export { STOP_EVENT_PROPAGATION } from "./util";
+
 export type Options = {
   date?: Date;
   minDate?: Date | $NOW;


### PR DESCRIPTION
I'm trying to work around some of the react reactivity issues which were surfaced in https://github.com/dan-lee/timescape/issues/40. However I need access to the internal symbol `STOP_EVENT_PROPAGATION`. This PR adds the symbol to the exports so I can use it.