### PR TITLE
Fix: re-entering parts after clearing changes the rest to today

### DIFF
--- a/.changeset/shy-clubs-feel.md
+++ b/.changeset/shy-clubs-feel.md
@@ -1,0 +1,5 @@
+---
+"timescape": patch
+---
+
+Fix: re-entering parts after clearing changes the rest to today

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -403,7 +403,9 @@ export class TimescapeManager implements Options {
   };
 
   get #currentDate(): Date {
-    return this.#timestamp ? new Date(this.#timestamp) : new Date();
+    if (this.#timestamp) return new Date(this.#timestamp);
+    if (this.#prevTimestamp) return new Date(this.#prevTimestamp);
+    return new Date();
   }
 
   #getValue(type: DateType): string {

--- a/packages/lib/test/timescape.test.ts
+++ b/packages/lib/test/timescape.test.ts
@@ -1074,6 +1074,52 @@ describe("timescape", () => {
       expect(manager.date).toBeUndefined();
     });
 
+    it("should keep previous date context when year is cleared and re-entered", async () => {
+      const initialDate = new Date("2012-02-29T10:00:00Z");
+
+      manager = new TimescapeManager();
+
+      container = register(manager, ["years", "months", "days"]);
+      manager.date = initialDate;
+      manager.resync();
+      document.body.appendChild(container);
+
+      const changes: Array<Date | undefined> = [];
+      const unsubscribe = manager.on("changeDate", (value) => {
+        changes.push(value);
+      });
+
+      const fields = getFields();
+
+      expect(fields.months).toHaveValue("02");
+      expect(fields.days).toHaveValue("29");
+
+      fields.years.focus();
+      await user.keyboard("{Backspace}{Backspace}{Backspace}{Backspace}");
+
+      expect(manager.date).toBeUndefined();
+      expect(changes.at(-1)).toBeUndefined();
+
+      await user.keyboard("2012");
+
+      expect(fields.months).toHaveValue("02");
+      expect(fields.days).toHaveValue("29");
+
+      const latestDate = manager.date;
+
+      expect(latestDate?.getFullYear()).toBe(2012);
+      expect(latestDate?.getMonth()).toBe(1);
+      expect(latestDate?.getDate()).toBe(29);
+
+      const lastChange = changes.at(-1);
+      expect(lastChange).toBeInstanceOf(Date);
+      expect(lastChange?.getFullYear()).toBe(2012);
+      expect(lastChange?.getMonth()).toBe(1);
+      expect(lastChange?.getDate()).toBe(29);
+
+      unsubscribe();
+    });
+
     it("should work with partial input disabled", async () => {
       const now = new Date();
       manager = new TimescapeManager(now, {


### PR DESCRIPTION
- close #60


Use previous partial timestamp when re-entering year and add regression test

when typing and reaches full digits, `setValue` uses `this.#currentDate` for the rest part. However, `this.#timestamp` is set to `undefined` when handling `Backspace`, so `this.#currentDate` becomes `new Date()`, which changes the existing date parts.


```ts
        const setValue = (unit: DateType, value: number) => {
          const newDate = set(this.#currentDate, unit, value);

```


!!! Note: this PR is mostly written by GPT Codex !!!


### Test plan

- run storybook, cannot reproduce the issue
- revert the code change, run test, failed; add code change back, run test, passed.



https://github.com/user-attachments/assets/b11f3dda-9817-406f-962f-c542c24b4c9b



